### PR TITLE
Implement multi-query map search MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,185 @@
+# Multi-Map Search
+
+This repository contains a zero-dependency MVP implementation of the multi-query map search experience outlined below. A lightweight Node.js server serves the static frontend and proxies search requests to the Overpass API so that multiple keyword searches can be visualised on a single MapLibre GL map.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18 or newer (for the built-in `fetch` API and ES2015 features)
+
+### Local development
+
+```bash
+npm run dev
+```
+
+The command starts the server on [http://localhost:3000](http://localhost:3000). The frontend is compiled as vanilla ES modules, so no bundler step is required. When developing, you can edit the files in `public/` and reload the browser.
+
+### Project structure
+
+```
+public/
+  index.html        # UI layout, MapLibre / Supercluster CDN bindings
+  styles.css        # Tailored dark UI with responsive layout
+  src/app.js        # Core application logic (state, map, filters, URL sync)
+server/
+  server.js         # Static file server + Overpass proxy with caching & throttling
+```
+
+### Key capabilities implemented
+
+- Up to five concurrent keyword queries, each auto-assigned a unique colour chip.
+- Manual “このエリアで再検索” trigger after panning/zooming, with shareable URL state.
+- MapLibre GL basemap with Supercluster-powered clustering and multi-colour ring markers for overlapping POIs.
+- Deduplication of points within ±30 m and a detail panel that cycles through stacked results at the same coordinate.
+- Filters for “営業中のみ” (powered by the `opening_hours` library) and distance radius in kilometres.
+- Backend-for-frontend layer that proxies Overpass API queries, normalises POI metadata, caches responses for 5 minutes, and enforces a small concurrent request cap.
+
+---
+
+# Multi-Map Search MVP Plan
+
+## 1. Goal
+Build a mobile-first web application that lets users run up to five different place searches (e.g., `鶴見 × 「ローソン」「銭湯」「スーパー」`) on the same map, visualize the results with distinct colors, and move seamlessly from discovery to action (navigation, sharing) with minimal interaction.
+
+## 2. MVP Scope & Requirements
+
+### Supported Platforms
+- Latest two major versions of Chrome, Safari, Edge, and Firefox.
+- Responsive layout with a smartphone-first experience.
+
+### Map & Search
+- Map SDK: **Mapbox GL JS** (preferred for richer UI) or **Leaflet + MapTiler tiles**.
+- Up to 5 simultaneous search queries per session.
+- Queries execute against a center point (current location or custom) and within the visible map bounds.
+- Data provider (choose one for MVP):
+  - **Google Places API** (recommended for accuracy, ratings, hours; paid with display requirements).
+  - **Overpass API (OSM)** as a low-cost alternative (limited POI metadata).
+- Manual reload via "Search this area" button after pan/zoom (auto reload as a post-MVP enhancement).
+
+### Display & Interaction
+- Automatic color/icon assignment per query with a visible legend and layer toggles.
+- Cluster markers when zoomed out.
+- Pin card details: name, address, opening hours (if available), phone number, quick links to Google/Apple Maps.
+- Deduplicate POIs within ±30 m: merge into a single marker with layered rings or a badge count indicating multiple hits.
+- Legend updates show active layer counts; toggles hide/show layers.
+
+### Filters & Sorting
+- Filters: `openNow`, distance radius (e.g., within N km).
+- Sorting: by distance or rating (when available from the provider).
+
+### Save & Share
+- Encode map state in the URL: center, zoom, queries (with assigned colors), filters, layer visibility.
+- Opening a shared URL reproduces the same map state.
+
+### Error Handling & UX
+- User-friendly error messages (e.g., "結果が取得できませんでした") with retry controls.
+- Explicit geolocation permission prompt; HTTPS required.
+
+### Performance Targets
+- Time-to-Interactive ≤ 2.5 s on first load over 4G (mid-tier smartphone).
+- Map re-render after panning ≤ 300 ms.
+- Search response (query to rendered markers) ≤ 3 s at p95 in realistic scenarios.
+
+## 3. Screen Flow
+1. **Landing** – Query input (comma-separated or tag chips), geolocation prompt, optional manual center input.
+2. **Map View** – Scrollable legend chips, "Search this area" CTA, current location button (bottom-right).
+3. **Pin Details** – Marker tap opens a card with action buttons for external navigation or phone dial.
+4. **Share** – Copyable URL reflecting the current map state.
+
+## 4. URL Schema (example)
+```
+/m?c=35.5089,139.6792&z=13&q=ローソン:red,銭湯:blue,スーパー:green&f=openNow:true,radius:2000&v=lawson:true,sento:true,super:true
+```
+- `c`: Center latitude/longitude.
+- `z`: Zoom level.
+- `q`: `query:color` entries.
+- `f`: Filters.
+- `v`: Visibility flags per layer.
+
+## 5. Frontend Data Model
+```ts
+interface MapState {
+  center: [number, number];
+  zoom: number;
+  queries: QueryLayer[];
+  filters: Filters;
+  visibleLayers: Record<string, boolean>;
+}
+
+interface QueryLayer {
+  id: string;
+  label: string;
+  color: string;
+  bbox: [number, number, number, number]; // swLng, swLat, neLng, neLat
+  items: POI[];
+}
+
+interface POI {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  address?: string;
+  sourceId: string;
+  categories?: string[];
+  rating?: number;
+  openNow?: boolean;
+  phone?: string;
+}
+```
+
+## 6. Backend / BFF Responsibilities
+- Hide API keys, normalize results, throttle request volume, and provide short-term caching (≈5 minutes).
+- Suggested endpoints:
+  - `GET /search?bbox=<bbox>&q=<query>` → normalized POI array.
+  - `GET /places?ids=<comma-separated>` → enriched details when the card opens.
+- Cache key strategy: `provider + bbox + query`.
+- Rate limiting: debounce search inputs (~600 ms) and enforce max concurrent requests (e.g., 5).
+
+## 7. Technology Choices
+- Frontend: **React** with **Vite** or **Next.js** (SSG-friendly).
+- Styling: **Tailwind CSS** or CSS Modules.
+- Map: **Mapbox GL JS** (primary) or **Leaflet** fallback.
+- Hosting: **Vercel** or **Netlify**.
+- Monitoring: Vercel Analytics, Sentry for errors, `web-vitals` for performance.
+
+## 8. Delivery Criteria
+- Render 3+ queries simultaneously with distinct colors.
+- Legend toggles update visibility and counts accordingly.
+- Co-located POIs merge with a composite marker; the detail card allows cycling through overlapped entries.
+- Shared URLs restore full state on load.
+- Achieve sub-3-second search-to-render on 4G (p95).
+
+## 9. Post-MVP Roadmap
+- Automatic re-query on map move.
+- Enhanced pin list sorting, favorites (local or anonymous ID).
+- CSV/GeoJSON export (lower priority for general users).
+- PWA support, multi-stop routing, visit notes, calendar integration.
+- Layers for reviews, crowding, isochrones.
+- Social sharing with generated OG images.
+
+## 10. Implementation Milestones
+1. **Foundation** – Project scaffolding, map rendering, geolocation, and responsive layout.
+2. **Query Engine** – Multi-query input, API integration (BFF + provider), dedupe logic.
+3. **Visualization** – Color assignment, clustering, legend toggles, marker cards with actions.
+4. **State Management** – URL encoding/decoding, filter persistence, error handling.
+5. **Optimization & QA** – Performance tuning, accessibility pass, analytics & monitoring hooks.
+
+## 11. Testing & Quality
+- Unit tests for utility functions (URL encoder/decoder, dedupe).
+- Integration tests for BFF endpoints (with mocked provider responses).
+- E2E smoke tests (Playwright/Cypress) covering query flow, pin interaction, sharing.
+- Performance budgets monitored via Lighthouse CI on representative devices.
+
+## 12. Risk & Mitigation Notes
+- **API Cost**: Monitor Google Places usage; set quotas and alerts.
+- **Rate Limits**: Implement caching/backoff, show friendly errors if provider throttles.
+- **Data Quality**: Provide fallback when hours/rating unavailable (display "情報なし").
+- **Privacy**: Ensure geolocation consent and secure handling of analytics data.
+
+## 13. Rough Effort Estimate
+- MVP design + implementation: 3–5 person-weeks assuming one data provider and existing UI library.
+- Operating cost: Map tiles + Places API consumption (likely within free tier initially; scales to several thousand JPY/month depending on usage).
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "multi-map-search",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Multi-Map Search MVP implementation with static frontend and Overpass proxy server.",
+  "main": "server/server.js",
+  "scripts": {
+    "dev": "node server/server.js",
+    "start": "node server/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Multi-Map Search</title>
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@3.6.1/dist/maplibre-gl.css" />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="branding">
+        <h1>Multi-Map Search</h1>
+        <p class="tagline">複数クエリを色分けして比較・発見・共有</p>
+      </div>
+      <button id="locate-btn" class="ghost-btn" type="button">現在地</button>
+    </header>
+
+    <main class="layout">
+      <section class="controls" aria-label="検索コントロール">
+        <form id="query-form" class="query-form">
+          <label for="query-input">検索キーワード（最大5件）</label>
+          <div class="query-input-row">
+            <input id="query-input" type="text" placeholder="例：ローソン、銭湯、スーパー" autocomplete="off" />
+            <button type="submit" class="primary-btn">追加</button>
+          </div>
+        </form>
+        <div id="query-chips" class="query-chips" aria-live="polite"></div>
+
+        <div class="filters">
+          <h2>フィルター</h2>
+          <label class="filter-item">
+            <input type="checkbox" id="filter-open-now" />
+            <span>営業中のみ</span>
+          </label>
+          <label class="filter-item">
+            <span>距離</span>
+            <div class="filter-input">
+              <input type="number" id="filter-radius" min="0" step="0.5" placeholder="km" />
+              <span class="suffix">km以内</span>
+            </div>
+          </label>
+          <div class="filter-actions">
+            <button id="apply-filters" class="secondary-btn" type="button">フィルター適用</button>
+            <button id="reset-filters" class="ghost-btn" type="button">リセット</button>
+          </div>
+        </div>
+
+        <div class="legend" aria-live="polite">
+          <h2>凡例</h2>
+          <div id="legend-items" class="legend-items"></div>
+        </div>
+      </section>
+
+      <section class="map-wrapper" aria-label="マップ">
+        <div id="map" class="map"></div>
+        <button id="search-area-btn" class="search-area-btn" type="button" disabled>このエリアで再検索</button>
+        <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+      </section>
+    </main>
+
+    <aside id="detail-panel" class="detail-panel" aria-live="polite" hidden>
+      <div class="detail-header">
+        <div id="detail-badges" class="detail-badges"></div>
+        <button id="detail-close" class="ghost-btn" type="button" aria-label="閉じる">✕</button>
+      </div>
+      <div class="detail-body">
+        <h2 id="detail-title"></h2>
+        <p id="detail-address" class="detail-address"></p>
+        <p id="detail-status" class="detail-status"></p>
+        <ul id="detail-meta" class="detail-meta"></ul>
+      </div>
+      <div class="detail-footer">
+        <div class="detail-nav" id="detail-nav" hidden>
+          <button id="detail-prev" type="button" class="ghost-btn">前へ</button>
+          <span id="detail-index"></span>
+          <button id="detail-next" type="button" class="ghost-btn">次へ</button>
+        </div>
+        <div class="detail-actions">
+          <a id="detail-open-google" class="primary-btn" target="_blank" rel="noreferrer">Googleマップで開く</a>
+          <a id="detail-open-apple" class="secondary-btn" target="_blank" rel="noreferrer">Appleマップで開く</a>
+        </div>
+      </div>
+    </aside>
+
+    <script src="https://unpkg.com/maplibre-gl@3.6.1/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/supercluster@7.1.5/dist/supercluster.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/opening_hours@3.13.0/opening_hours.js"></script>
+    <script type="module" src="./src/app.js"></script>
+  </body>
+</html>

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -1,0 +1,758 @@
+const colorPalette = ['#f97316', '#38bdf8', '#34d399', '#f472b6', '#c084fc', '#facc15', '#fb7185'];
+
+const defaultState = {
+  center: { lat: 35.681236, lng: 139.767125 },
+  zoom: 12,
+  queries: [],
+  filters: { openNow: false, radius: null },
+  visible: [],
+};
+
+const state = structuredClone(defaultState);
+const queryResults = new Map();
+let map;
+let mapReady = false;
+let clusterIndex = null;
+let markers = [];
+let needsSearch = false;
+let searchCenter = null;
+let searchZoom = null;
+let detailContext = null;
+
+const mapContainer = document.getElementById('map');
+const queryForm = document.getElementById('query-form');
+const queryInput = document.getElementById('query-input');
+const queryChips = document.getElementById('query-chips');
+const legendContainer = document.getElementById('legend-items');
+const searchAreaBtn = document.getElementById('search-area-btn');
+const toastEl = document.getElementById('toast');
+const filterOpenNow = document.getElementById('filter-open-now');
+const filterRadius = document.getElementById('filter-radius');
+const applyFiltersBtn = document.getElementById('apply-filters');
+const resetFiltersBtn = document.getElementById('reset-filters');
+const locateBtn = document.getElementById('locate-btn');
+
+const detailPanel = document.getElementById('detail-panel');
+const detailBadges = document.getElementById('detail-badges');
+const detailCloseBtn = document.getElementById('detail-close');
+const detailTitle = document.getElementById('detail-title');
+const detailAddress = document.getElementById('detail-address');
+const detailStatus = document.getElementById('detail-status');
+const detailMeta = document.getElementById('detail-meta');
+const detailPrev = document.getElementById('detail-prev');
+const detailNext = document.getElementById('detail-next');
+const detailNav = document.getElementById('detail-nav');
+const detailIndex = document.getElementById('detail-index');
+const detailOpenGoogle = document.getElementById('detail-open-google');
+const detailOpenApple = document.getElementById('detail-open-apple');
+
+function structuredClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function slugify(label) {
+  return label
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32) || 'query';
+}
+
+function showToast(message, duration = 2600) {
+  toastEl.textContent = message;
+  toastEl.hidden = false;
+  setTimeout(() => {
+    toastEl.hidden = true;
+  }, duration);
+}
+
+function pickColor(existingColors) {
+  for (const color of colorPalette) {
+    if (!existingColors.has(color)) {
+      return color;
+    }
+  }
+  return colorPalette[Math.floor(Math.random() * colorPalette.length)];
+}
+
+function addQuery(label, color) {
+  const trimmed = label.trim();
+  if (!trimmed) {
+    return;
+  }
+  if (state.queries.length >= 5) {
+    showToast('クエリは最大5件までです');
+    return;
+  }
+  const exists = state.queries.some((q) => q.label === trimmed);
+  if (exists) {
+    showToast('同じクエリが既に存在します');
+    return;
+  }
+  const colorsInUse = new Set(state.queries.map((q) => q.color));
+  const generatedId =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `q-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const query = {
+    id: generatedId,
+    key: slugify(trimmed),
+    label: trimmed,
+    color: color || pickColor(colorsInUse),
+    enabled: true,
+  };
+  state.queries.push(query);
+  queryResults.delete(query.id);
+  renderQueryChips();
+  renderLegend();
+  updateSearchButtonState();
+  updateUrlState();
+}
+
+function removeQuery(id) {
+  const index = state.queries.findIndex((q) => q.id === id);
+  if (index === -1) return;
+  state.queries.splice(index, 1);
+  queryResults.delete(id);
+  renderQueryChips();
+  renderLegend();
+  applyFiltersAndRender();
+  updateSearchButtonState();
+  updateUrlState();
+}
+
+function renderQueryChips() {
+  queryChips.innerHTML = '';
+  state.queries.forEach((query) => {
+    const chip = document.createElement('div');
+    chip.className = 'query-chip';
+    const colorEl = document.createElement('span');
+    colorEl.className = 'query-color';
+    colorEl.style.background = query.color;
+    chip.appendChild(colorEl);
+
+    const labelEl = document.createElement('span');
+    labelEl.textContent = query.label;
+    chip.appendChild(labelEl);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '削除';
+    removeBtn.addEventListener('click', () => removeQuery(query.id));
+    chip.appendChild(removeBtn);
+
+    queryChips.appendChild(chip);
+  });
+}
+
+function renderLegend(counts = {}) {
+  legendContainer.innerHTML = '';
+  state.queries.forEach((query, index) => {
+    const count = counts[query.id] || 0;
+    const item = document.createElement('div');
+    item.className = 'legend-item';
+    item.dataset.enabled = String(query.enabled);
+    item.dataset.queryId = query.id;
+
+    const left = document.createElement('div');
+    left.className = 'legend-left';
+
+    const color = document.createElement('span');
+    color.className = 'legend-color';
+    color.style.background = query.color;
+    left.appendChild(color);
+
+    const textWrap = document.createElement('div');
+    const label = document.createElement('div');
+    label.textContent = query.label;
+    const counter = document.createElement('div');
+    counter.textContent = `${count}件`;
+    counter.style.color = 'var(--muted)';
+    counter.style.fontSize = '0.85rem';
+    textWrap.append(label, counter);
+    left.appendChild(textWrap);
+
+    const toggle = document.createElement('div');
+    toggle.className = 'legend-toggle';
+    toggle.setAttribute('role', 'switch');
+    toggle.setAttribute('aria-checked', query.enabled ? 'true' : 'false');
+    toggle.tabIndex = 0;
+
+    toggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      toggleQuery(query.id);
+    });
+    toggle.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleQuery(query.id);
+      }
+    });
+
+    item.append(left, toggle);
+    legendContainer.appendChild(item);
+  });
+}
+
+function toggleQuery(id) {
+  const query = state.queries.find((q) => q.id === id);
+  if (!query) return;
+  query.enabled = !query.enabled;
+  renderLegend(currentCounts);
+  applyFiltersAndRender();
+  updateUrlState();
+}
+
+const currentCounts = {};
+
+function updateSearchButtonState() {
+  searchAreaBtn.disabled = !mapReady || state.queries.length === 0;
+}
+
+function parseInitialState() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('c')) {
+    const [latStr, lngStr] = params.get('c').split(',');
+    const lat = parseFloat(latStr);
+    const lng = parseFloat(lngStr);
+    if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+      state.center = { lat, lng };
+    }
+  }
+  if (params.has('z')) {
+    const zoom = parseFloat(params.get('z'));
+    if (!Number.isNaN(zoom)) {
+      state.zoom = zoom;
+    }
+  }
+  if (params.has('f')) {
+    const parts = params.get('f').split(',');
+    parts.forEach((part) => {
+      const [key, value] = part.split(':');
+      if (key === 'openNow') {
+        state.filters.openNow = value === 'true';
+      }
+      if (key === 'radius') {
+        const radius = parseFloat(value);
+        if (!Number.isNaN(radius)) {
+          state.filters.radius = radius;
+        }
+      }
+    });
+  }
+  if (params.has('q')) {
+    const entries = params.get('q').split(',');
+    entries.forEach((entry) => {
+      const [labelPart, colorPart] = entry.split(':');
+      if (!labelPart) return;
+      const label = decodeURIComponent(labelPart);
+      const color = colorPart ? decodeURIComponent(colorPart) : undefined;
+      addQuery(label, color);
+    });
+  }
+  if (params.has('v')) {
+    const visibilityEntries = params.get('v').split(',');
+    visibilityEntries.forEach((entry) => {
+      const [idxStr, value] = entry.split(':');
+      const idx = parseInt(idxStr, 10);
+      if (!Number.isNaN(idx) && state.queries[idx]) {
+        state.queries[idx].enabled = value !== 'false';
+      }
+    });
+  }
+
+  filterOpenNow.checked = state.filters.openNow;
+  if (state.filters.radius != null) {
+    filterRadius.value = state.filters.radius;
+  }
+}
+
+function updateUrlState() {
+  if (!map) return;
+  const params = new URLSearchParams();
+  const center = map.getCenter();
+  params.set('c', `${center.lat.toFixed(5)},${center.lng.toFixed(5)}`);
+  params.set('z', map.getZoom().toFixed(2));
+  if (state.queries.length > 0) {
+    const queryParam = state.queries
+      .map((q) => `${encodeURIComponent(q.label)}:${encodeURIComponent(q.color)}`)
+      .join(',');
+    params.set('q', queryParam);
+    const visibility = state.queries
+      .map((q, index) => `${index}:${q.enabled ? 'true' : 'false'}`)
+      .join(',');
+    params.set('v', visibility);
+  }
+  const filterParts = [];
+  if (state.filters.openNow) {
+    filterParts.push('openNow:true');
+  }
+  if (state.filters.radius != null && state.filters.radius !== '') {
+    filterParts.push(`radius:${state.filters.radius}`);
+  }
+  if (filterParts.length > 0) {
+    params.set('f', filterParts.join(','));
+  }
+  const url = `${window.location.pathname}?${params.toString()}`;
+  window.history.replaceState({}, '', url);
+}
+
+function haversine(lat1, lon1, lat2, lon2) {
+  const toRad = (value) => (value * Math.PI) / 180;
+  const R = 6371; // km
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+function dedupePois(pois) {
+  const groups = [];
+  const thresholdKm = 0.03; // 30m
+  pois.forEach((poi) => {
+    let group = groups.find((g) => haversine(g.lat, g.lng, poi.lat, poi.lng) <= thresholdKm);
+    if (!group) {
+      group = {
+        lat: poi.lat,
+        lng: poi.lng,
+        items: [],
+        colors: new Set(),
+      };
+      groups.push(group);
+    }
+    group.items.push(poi);
+    group.colors.add(poi.color);
+  });
+  return groups.map((group) => ({
+    lat: group.lat,
+    lng: group.lng,
+    items: group.items,
+    colors: Array.from(group.colors),
+  }));
+}
+
+function computeOpenNow(poi) {
+  if (!poi.openingHours) {
+    return null;
+  }
+  if (typeof window.opening_hours === 'undefined') {
+    return null;
+  }
+  try {
+    const oh = new window.opening_hours(poi.openingHours);
+    return oh.getState();
+  } catch (error) {
+    return null;
+  }
+}
+
+function decoratePoi(poi) {
+  if (typeof poi.openNow === 'boolean' || poi.openNow === null) {
+    poi.computedOpenNow = poi.openNow;
+  } else {
+    poi.computedOpenNow = computeOpenNow(poi);
+  }
+  return poi;
+}
+
+function applyFiltersAndRender() {
+  const activeQueries = state.queries.filter((q) => q.enabled);
+  const filterOpen = state.filters.openNow;
+  const radiusKm = state.filters.radius != null && state.filters.radius !== '' ? Number(state.filters.radius) : null;
+  const baseCenter = searchCenter || (map ? map.getCenter() : { lat: state.center.lat, lng: state.center.lng });
+  const filtered = [];
+  const counts = {};
+
+  activeQueries.forEach((query) => {
+    const items = queryResults.get(query.id) || [];
+    items.forEach((poi) => {
+      const decorated = decoratePoi({ ...poi });
+      if (filterOpen && decorated.computedOpenNow === false) {
+        return;
+      }
+      if (radiusKm != null) {
+        const distance = haversine(baseCenter.lat, baseCenter.lng, decorated.lat, decorated.lng);
+        if (distance > radiusKm) {
+          return;
+        }
+        decorated.distance = distance;
+      }
+      filtered.push({ ...decorated, queryId: query.id, color: query.color });
+      counts[query.id] = (counts[query.id] || 0) + 1;
+    });
+  });
+
+  state.queries.forEach((query) => {
+    if (!counts[query.id]) {
+      counts[query.id] = 0;
+    }
+  });
+  Object.keys(currentCounts).forEach((key) => {
+    delete currentCounts[key];
+  });
+  Object.assign(currentCounts, counts);
+  renderLegend(counts);
+
+  const deduped = dedupePois(filtered);
+  buildClusters(deduped);
+  renderMarkers();
+}
+
+function buildClusters(groups) {
+  if (!window.Supercluster) {
+    return;
+  }
+  clusterIndex = new window.Supercluster({
+    radius: 70,
+    maxZoom: 18,
+    minPoints: 2,
+  });
+  const features = groups.map((group, idx) => ({
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [group.lng, group.lat] },
+    properties: {
+      cluster: false,
+      id: `group-${idx}`,
+      items: group.items,
+      colors: group.colors,
+    },
+  }));
+  clusterIndex.load(features);
+}
+
+function clearMarkers() {
+  markers.forEach((marker) => marker.remove());
+  markers = [];
+}
+
+function renderMarkers() {
+  if (!clusterIndex || !map) {
+    clearMarkers();
+    return;
+  }
+  const bounds = map.getBounds();
+  const zoom = Math.floor(map.getZoom());
+  const clusters = clusterIndex.getClusters(
+    [bounds.getWest(), bounds.getSouth(), bounds.getEast(), bounds.getNorth()],
+    zoom
+  );
+  clearMarkers();
+  clusters.forEach((feature) => {
+    const { coordinates } = feature.geometry;
+    const [lng, lat] = coordinates;
+    const markerEl = document.createElement('div');
+    let marker;
+    if (feature.properties.cluster) {
+      markerEl.className = 'cluster-marker';
+      markerEl.textContent = feature.properties.point_count_abbreviated;
+      marker = new maplibregl.Marker({ element: markerEl }).setLngLat([lng, lat]).addTo(map);
+      markerEl.addEventListener('click', () => {
+        const clusterId = feature.id ?? feature.properties.cluster_id;
+        const expansionZoom = Math.min(clusterIndex.getClusterExpansionZoom(clusterId), 20);
+        map.easeTo({ center: [lng, lat], zoom: expansionZoom });
+      });
+    } else {
+      markerEl.className = 'marker';
+      markerEl.dataset.multi = feature.properties.colors.length > 1 ? 'true' : 'false';
+      const colors = feature.properties.colors;
+      if (colors.length === 1) {
+        markerEl.style.background = colors[0];
+      } else {
+        const segments = colors
+          .map((color, idx) => {
+            const start = (idx / colors.length) * 100;
+            const end = ((idx + 1) / colors.length) * 100;
+            return `${color} ${start}% ${end}%`;
+          })
+          .join(', ');
+        markerEl.style.background = `conic-gradient(${segments})`;
+      }
+      marker = new maplibregl.Marker({ element: markerEl }).setLngLat([lng, lat]).addTo(map);
+      markerEl.addEventListener('click', () => {
+        openDetail(feature.properties.items, { lat, lng });
+      });
+    }
+    markers.push(marker);
+  });
+}
+
+function openDetail(items, coordinate) {
+  if (!items || items.length === 0) {
+    return;
+  }
+  detailContext = { items, index: 0, coordinate };
+  updateDetailPanel();
+  detailPanel.hidden = false;
+}
+
+function updateDetailPanel() {
+  if (!detailContext) return;
+  const { items, index } = detailContext;
+  const current = items[index];
+  if (!current) return;
+
+  detailBadges.innerHTML = '';
+  const uniqueQueries = new Map();
+  items.forEach((item) => {
+    if (!uniqueQueries.has(item.queryId)) {
+      const query = state.queries.find((q) => q.id === item.queryId);
+      if (query) {
+        uniqueQueries.set(item.queryId, query);
+      }
+    }
+  });
+  uniqueQueries.forEach((query) => {
+    const badge = document.createElement('span');
+    badge.className = 'detail-badge';
+    const swatch = document.createElement('span');
+    swatch.className = 'query-color';
+    swatch.style.background = query.color;
+    swatch.style.width = '12px';
+    swatch.style.height = '12px';
+    badge.appendChild(swatch);
+    const text = document.createElement('span');
+    text.textContent = query.label;
+    badge.appendChild(text);
+    detailBadges.appendChild(badge);
+  });
+
+  detailTitle.textContent = current.name || '名称不明';
+  detailAddress.textContent = current.address || '住所情報なし';
+
+  const openNow = decoratePoi(current).computedOpenNow;
+  if (openNow === true) {
+    detailStatus.textContent = '営業中';
+    detailStatus.style.color = '#34d399';
+  } else if (openNow === false) {
+    detailStatus.textContent = '営業時間外';
+    detailStatus.style.color = '#f97316';
+  } else {
+    detailStatus.textContent = '営業時間情報なし';
+    detailStatus.style.color = 'var(--muted)';
+  }
+
+  detailMeta.innerHTML = '';
+  if (current.openingHours) {
+    const li = document.createElement('li');
+    li.textContent = `営業時間: ${current.openingHours}`;
+    detailMeta.appendChild(li);
+  }
+  if (current.phone) {
+    const li = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = `tel:${current.phone}`;
+    link.textContent = current.phone;
+    link.style.color = 'inherit';
+    link.style.textDecoration = 'none';
+    li.textContent = '電話: ';
+    li.appendChild(link);
+    detailMeta.appendChild(li);
+  }
+  if (current.website) {
+    const li = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = current.website;
+    link.target = '_blank';
+    link.rel = 'noreferrer';
+    link.textContent = current.website;
+    link.style.color = 'inherit';
+    li.textContent = 'Web: ';
+    li.appendChild(link);
+    detailMeta.appendChild(li);
+  }
+  if (current.categories && current.categories.length > 0) {
+    const li = document.createElement('li');
+    li.textContent = `カテゴリ: ${current.categories.join(', ')}`;
+    detailMeta.appendChild(li);
+  }
+  if (current.distance != null) {
+    const li = document.createElement('li');
+    li.textContent = `距離: 約${current.distance.toFixed(2)} km`;
+    detailMeta.appendChild(li);
+  }
+
+  if (items.length > 1) {
+    detailNav.hidden = false;
+    detailIndex.textContent = `${index + 1} / ${items.length}`;
+  } else {
+    detailNav.hidden = true;
+  }
+
+  const googleUrl = `https://www.google.com/maps/search/?api=1&query=${current.lat},${current.lng}`;
+  const appleUrl = `https://maps.apple.com/?ll=${current.lat},${current.lng}&q=${encodeURIComponent(
+    current.name || 'POI'
+  )}`;
+  detailOpenGoogle.href = googleUrl;
+  detailOpenApple.href = appleUrl;
+}
+
+function closeDetail() {
+  detailPanel.hidden = true;
+  detailContext = null;
+}
+
+detailPrev.addEventListener('click', () => {
+  if (!detailContext) return;
+  detailContext.index = (detailContext.index - 1 + detailContext.items.length) % detailContext.items.length;
+  updateDetailPanel();
+});
+
+detailNext.addEventListener('click', () => {
+  if (!detailContext) return;
+  detailContext.index = (detailContext.index + 1) % detailContext.items.length;
+  updateDetailPanel();
+});
+
+detailCloseBtn.addEventListener('click', closeDetail);
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    closeDetail();
+  }
+});
+
+function fetchQuery(query, bounds) {
+  const bbox = `${bounds.getSouth()},${bounds.getWest()},${bounds.getNorth()},${bounds.getEast()}`;
+  const url = `/api/search?bbox=${encodeURIComponent(bbox)}&q=${encodeURIComponent(query.label)}`;
+  return fetch(url)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error('検索に失敗しました');
+      }
+      return res.json();
+    })
+    .then((payload) => {
+      const items = (payload.items || []).map((poi) => ({ ...poi, queryId: query.id, color: query.color }));
+      queryResults.set(query.id, items);
+    })
+    .catch((error) => {
+      showToast(`${query.label} の取得に失敗しました`);
+      console.error(error);
+      queryResults.set(query.id, []);
+    });
+}
+
+function runSearch(reason = 'manual') {
+  if (!map || !mapReady || state.queries.length === 0) {
+    return;
+  }
+  const bounds = map.getBounds();
+  searchAreaBtn.disabled = true;
+  needsSearch = false;
+  showToast('検索しています…');
+  const promises = state.queries.map((query) => fetchQuery(query, bounds));
+  Promise.all(promises).then(() => {
+    searchCenter = map.getCenter();
+    searchZoom = map.getZoom();
+    showToast('検索が完了しました');
+    applyFiltersAndRender();
+    updateUrlState();
+  });
+}
+
+function initMap() {
+  map = new maplibregl.Map({
+    container: mapContainer,
+    style: 'https://demotiles.maplibre.org/style.json',
+    center: [state.center.lng, state.center.lat],
+    zoom: state.zoom,
+    attributionControl: true,
+  });
+  map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'bottom-right');
+  map.addControl(new maplibregl.ScaleControl({ maxWidth: 120, unit: 'metric' }), 'bottom-left');
+
+  map.on('load', () => {
+    mapReady = true;
+    updateSearchButtonState();
+    if (state.queries.length > 0) {
+      runSearch('initial');
+    }
+  });
+
+  map.on('moveend', () => {
+    updateUrlState();
+    if (!mapReady || state.queries.length === 0) return;
+    searchAreaBtn.disabled = false;
+    needsSearch = true;
+  });
+}
+
+function initForm() {
+  queryForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const value = queryInput.value;
+    if (!value.trim()) {
+      return;
+    }
+    const parts = value
+      .split(/[,\u3001]/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (parts.length === 0) {
+      return;
+    }
+    parts.forEach((part) => addQuery(part));
+    queryInput.value = '';
+    if (mapReady && state.queries.length > 0) {
+      runSearch('add-query');
+    }
+  });
+}
+
+function initFilters() {
+  applyFiltersBtn.addEventListener('click', () => {
+    state.filters.openNow = filterOpenNow.checked;
+    state.filters.radius = filterRadius.value ? Number(filterRadius.value) : null;
+    applyFiltersAndRender();
+    updateUrlState();
+  });
+
+  resetFiltersBtn.addEventListener('click', () => {
+    state.filters.openNow = false;
+    state.filters.radius = null;
+    filterOpenNow.checked = false;
+    filterRadius.value = '';
+    applyFiltersAndRender();
+    updateUrlState();
+  });
+}
+
+function initSearchButton() {
+  searchAreaBtn.addEventListener('click', () => {
+    if (mapReady && state.queries.length > 0) {
+      runSearch('button');
+    }
+  });
+}
+
+function initLocateButton() {
+  locateBtn.addEventListener('click', () => {
+    if (!navigator.geolocation) {
+      showToast('位置情報が利用できません');
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        map.easeTo({ center: [longitude, latitude], zoom: Math.max(map.getZoom(), 14) });
+      },
+      () => {
+        showToast('現在地を取得できませんでした');
+      },
+      { enableHighAccuracy: false, timeout: 5000 }
+    );
+  });
+}
+
+parseInitialState();
+initMap();
+initForm();
+initFilters();
+initSearchButton();
+initLocateButton();
+applyFiltersAndRender();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,441 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --surface: rgba(15, 23, 42, 0.85);
+  --panel: rgba(15, 23, 42, 0.6);
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #f8fafc;
+  --muted: rgba(248, 250, 252, 0.6);
+  --accent: #38bdf8;
+  --shadow: rgba(15, 23, 42, 0.3);
+  font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.15), transparent),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.98));
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.2rem clamp(1rem, 5vw, 2rem);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(16px);
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.branding .tagline {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  overflow: hidden;
+}
+
+.controls {
+  padding: clamp(1rem, 4vw, 1.5rem);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.6));
+}
+
+.controls h2 {
+  font-size: 1rem;
+  margin: 1.5rem 0 0.75rem;
+}
+
+.query-form label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.query-input-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+input[type='text'],
+input[type='number'] {
+  flex: 1;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+}
+
+input[type='text']::placeholder,
+input[type='number']::placeholder {
+  color: rgba(248, 250, 252, 0.4);
+}
+
+button {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, #38bdf8, #4f46e5);
+  color: white;
+  padding: 0.65rem 1.4rem;
+  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.3);
+}
+
+.secondary-btn {
+  background: rgba(59, 130, 246, 0.15);
+  color: var(--text);
+  padding: 0.65rem 1.4rem;
+  border: 1px solid rgba(56, 189, 248, 0.4);
+}
+
+.ghost-btn {
+  background: transparent;
+  color: var(--muted);
+  padding: 0.5rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.25);
+}
+
+.query-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.query-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem 0.35rem 0.35rem;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.query-color {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid rgba(15, 23, 42, 0.8);
+}
+
+.query-chip button {
+  background: transparent;
+  color: var(--muted);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.6rem;
+}
+
+.filters {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.filter-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0.75rem 0;
+  gap: 1rem;
+}
+
+.filter-input {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.filter-input input {
+  width: 80px;
+}
+
+.legend {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.legend-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.legend-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.legend-toggle {
+  width: 42px;
+  height: 24px;
+  background: rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.legend-toggle::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: white;
+  transition: transform 0.2s ease;
+}
+
+.legend-item[data-enabled='true'] .legend-toggle {
+  background: rgba(56, 189, 248, 0.6);
+}
+
+.legend-item[data-enabled='true'] .legend-toggle::after {
+  transform: translateX(18px);
+}
+
+.legend-color {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid rgba(15, 23, 42, 0.6);
+}
+
+.map-wrapper {
+  position: relative;
+}
+
+.map {
+  width: 100%;
+  height: calc(100vh - 72px);
+}
+
+.search-area-btn {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.55rem 1.5rem;
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  z-index: 5;
+}
+
+.toast {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--text);
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.4);
+  z-index: 5;
+}
+
+.detail-panel {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+  max-width: 480px;
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 20px 20px 0 0;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.5);
+  padding: 1.25rem clamp(1rem, 4vw, 1.75rem);
+  z-index: 10;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.detail-badges {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.detail-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  font-size: 0.85rem;
+}
+
+.detail-title {
+  margin: 0.75rem 0 0.25rem;
+}
+
+.detail-address {
+  color: var(--muted);
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.detail-status {
+  margin: 0.75rem 0;
+  font-weight: 600;
+}
+
+.detail-meta {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.detail-meta li {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.detail-footer {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.detail-actions a {
+  text-decoration: none;
+  text-align: center;
+  flex: 1;
+}
+
+.detail-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.marker {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 3px solid rgba(15, 23, 42, 0.9);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.4);
+}
+
+.marker[data-multi='true'] {
+  border: 3px solid rgba(15, 23, 42, 0.9);
+}
+
+.cluster-marker {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(59, 130, 246, 0.9);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.4);
+  border: 2px solid rgba(15, 23, 42, 0.6);
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  .controls {
+    display: contents;
+  }
+
+  .filters,
+  .legend,
+  .query-form,
+  .query-chips {
+    padding-inline: clamp(1rem, 5vw, 1.5rem);
+  }
+
+  .map {
+    height: calc(100vh - 320px);
+  }
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .search-area-btn {
+    top: 20px;
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,233 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 3000;
+const PUBLIC_DIR = path.join(__dirname, '..', 'public');
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_CONCURRENT_PROVIDER_REQUESTS = 5;
+const USER_AGENT = 'MultiMapSearch/0.1 (+https://example.com)';
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.webmanifest': 'application/manifest+json',
+};
+
+const cache = new Map();
+let activeProviderRequests = 0;
+
+function log(...args) {
+  console.log(new Date().toISOString(), '-', ...args);
+}
+
+function sendJson(res, status, data) {
+  const payload = JSON.stringify(data);
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(payload),
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  });
+  res.end(payload);
+}
+
+function sendError(res, status, message) {
+  sendJson(res, status, { error: message });
+}
+
+function serveStatic(req, res, url) {
+  let pathname = url.pathname;
+  if (pathname === '/') {
+    pathname = '/index.html';
+  }
+  const filePath = path.join(PUBLIC_DIR, path.normalize(pathname.replace(/^\/+/, '')));
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403);
+    return res.end('Forbidden');
+  }
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end('Not found');
+      } else {
+        res.writeHead(500);
+        res.end('Server error');
+      }
+      return;
+    }
+    const ext = path.extname(filePath);
+    const type = mimeTypes[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+}
+
+function normalizePoi(element, queryLabel) {
+  const tags = element.tags || {};
+  const lat = element.lat || (element.center && element.center.lat);
+  const lon = element.lon || (element.center && element.center.lon);
+  if (typeof lat !== 'number' || typeof lon !== 'number') {
+    return null;
+  }
+  const id = `${element.type}/${element.id}`;
+  const name = tags.name || queryLabel;
+  const phone = tags.phone || tags['contact:phone'] || null;
+  const website = tags.website || tags.url || null;
+  const categories = [];
+  ['amenity', 'shop', 'tourism', 'leisure', 'office', 'craft', 'sport'].forEach((key) => {
+    if (tags[key]) {
+      categories.push(`${key}:${tags[key]}`);
+    }
+  });
+  const addressParts = [
+    tags['addr:full'],
+    [tags['addr:city'], tags['addr:district'], tags['addr:suburb']].filter(Boolean).join(' '),
+    [tags['addr:street'], tags['addr:housenumber']].filter(Boolean).join(' '),
+    tags['addr:postcode'],
+  ].filter(Boolean);
+  const address = addressParts.join(', ') || null;
+
+  return {
+    id,
+    name,
+    lat,
+    lng: lon,
+    address,
+    sourceId: id,
+    categories,
+    rating: tags.rating ? Number(tags.rating) : null,
+    openNow: null,
+    openingHours: tags.opening_hours || null,
+    phone,
+    website,
+    queryLabel,
+  };
+}
+
+async function fetchFromOverpass(bbox, queryLabel) {
+  const key = `overpass:${bbox}:${queryLabel}`;
+  const now = Date.now();
+  const cached = cache.get(key);
+  if (cached && cached.expires > now) {
+    return cached.value;
+  }
+
+  if (activeProviderRequests >= MAX_CONCURRENT_PROVIDER_REQUESTS) {
+    const error = new Error('Provider busy');
+    error.status = 429;
+    throw error;
+  }
+
+  activeProviderRequests += 1;
+  try {
+    const [south, west, north, east] = bbox.split(',').map((v) => parseFloat(v));
+    if ([south, west, north, east].some((v) => Number.isNaN(v))) {
+      const error = new Error('Invalid bounding box');
+      error.status = 400;
+      throw error;
+    }
+    const bboxClause = `${south},${west},${north},${east}`;
+    const escaped = queryLabel.replace(/"/g, '');
+    const query = `
+      [out:json][timeout:25];
+      (
+        node["name"~"${escaped}", i](${bboxClause});
+        way["name"~"${escaped}", i](${bboxClause});
+        relation["name"~"${escaped}", i](${bboxClause});
+        node["amenity"~"${escaped}", i](${bboxClause});
+        way["amenity"~"${escaped}", i](${bboxClause});
+        node["shop"~"${escaped}", i](${bboxClause});
+        way["shop"~"${escaped}", i](${bboxClause});
+      );
+      out center tags 40;
+    `;
+
+    const body = new URLSearchParams({ data: query });
+    const response = await fetch('https://overpass-api.de/api/interpreter', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        Accept: 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      const error = new Error(`Overpass error: ${response.status}`);
+      error.status = response.status;
+      throw error;
+    }
+
+    const payload = await response.json();
+    const pois = (payload.elements || [])
+      .map((element) => normalizePoi(element, queryLabel))
+      .filter(Boolean);
+
+    const result = { provider: 'overpass', query: queryLabel, items: pois };
+    cache.set(key, { value: result, expires: now + CACHE_TTL_MS });
+    return result;
+  } finally {
+    activeProviderRequests -= 1;
+  }
+}
+
+function handleSearch(req, res, url) {
+  const params = url.searchParams;
+  const bbox = params.get('bbox');
+  const queryLabel = params.get('q');
+  if (!bbox || !queryLabel) {
+    return sendError(res, 400, 'Missing bbox or q parameter');
+  }
+  fetchFromOverpass(bbox, queryLabel)
+    .then((result) => {
+      sendJson(res, 200, result);
+    })
+    .catch((error) => {
+      const status = error.status || 500;
+      log('Search error', status, error.message);
+      sendError(res, status, '結果が取得できませんでした');
+    });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    });
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (url.pathname === '/api/search') {
+    if (req.method !== 'GET') {
+      res.writeHead(405);
+      res.end('Method Not Allowed');
+      return;
+    }
+    handleSearch(req, res, url);
+    return;
+  }
+
+  serveStatic(req, res, url);
+});
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    log(`Server listening on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = server;


### PR DESCRIPTION
## Summary
- add a static MapLibre-based frontend that supports up to five colour-coded searches with clustering, filtering, deduplication, and shareable URL state
- style the UI for a responsive, mobile-first experience with legend toggles and a stacked detail panel
- introduce a Node.js BFF that serves the static assets, normalises Overpass API responses, caches results, and caps concurrent provider calls

## Testing
- node -e "require('./server/server.js'); console.log('server loaded')"

------
https://chatgpt.com/codex/tasks/task_e_68deccf57570832aa65339c8d6816984